### PR TITLE
Add reusable service modules

### DIFF
--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -1,0 +1,46 @@
+locals {
+  image_tag = lookup(yamldecode(file("../../versions.yml")), lower(var.service_name), "latest")
+}
+
+resource "aws_ecs_service" "service" {
+  count = var.webservice ? 0 : 1
+
+  name                               = var.service_name
+  cluster                            = data.tfe_outputs.infrastructure.values[var.region].ecs_cluster
+  task_definition                    = aws_ecs_task_definition.task.arn
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 200
+  launch_type                        = var.launch_type
+
+}
+
+resource "aws_cloudwatch_log_group" "aws_logs" {
+  name              = "/ecs/${var.service_name}"
+  retention_in_days = 14
+}
+
+resource "aws_ecs_task_definition" "task" {
+  family                   = var.service_name
+  cpu                      = var.esc_cpu
+  memory                   = var.esc_memory
+  execution_role_arn       = aws_iam_role.ecs-execution.arn
+  task_role_arn            = aws_iam_role.task-execution.arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = [var.launch_type]
+
+  container_definitions = jsonencode([merge(
+    {
+      name  = lower(var.service_name)
+      image = "${var.container_image}:${local.image_tag}"
+      logConfiguration : {
+        logDriver : "awslogs",
+        options : {
+          "awslogs-group" : aws_cloudwatch_log_group.aws_logs.name,
+          "awslogs-region" : var.region,
+          "awslogs-stream-prefix" : "ecs"
+        }
+      }
+    }, var.container_definitions)
+  ])
+}

--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -1,5 +1,5 @@
 locals {
-  image_tag = lookup(yamldecode(file("../../versions.yml")), lower(var.service_name), "latest")
+  image_tag = lookup(yamldecode(file("../versions.yml")), lower(var.service_name), "latest")
 }
 
 resource "aws_ecs_service" "service" {
@@ -22,8 +22,8 @@ resource "aws_cloudwatch_log_group" "aws_logs" {
 
 resource "aws_ecs_task_definition" "task" {
   family                   = var.service_name
-  cpu                      = var.esc_cpu
-  memory                   = var.esc_memory
+  cpu                      = var.ecs_cpu
+  memory                   = var.ecs_memory
   execution_role_arn       = aws_iam_role.ecs-execution.arn
   task_role_arn            = aws_iam_role.task-execution.arn
   network_mode             = "awsvpc"

--- a/.modules/service/module.tf
+++ b/.modules/service/module.tf
@@ -1,0 +1,4 @@
+data "tfe_outputs" "infrastructure" {
+  organization = "home_assistant"
+  workspace    = "infrastructure"
+}

--- a/.modules/service/outputs.tf
+++ b/.modules/service/outputs.tf
@@ -1,0 +1,4 @@
+output "task_definition" {
+  description = "The ARN for the taks definition"
+  value       = aws_ecs_task_definition.task.arn
+}

--- a/.modules/service/policy.tf
+++ b/.modules/service/policy.tf
@@ -1,0 +1,48 @@
+data "aws_iam_policy_document" "ecs-role-policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["ecs-tasks.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs-execution" {
+  name               = "${var.service_name}-ExecutionRole-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs-role-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-execution-managed" {
+  role       = aws_iam_role.ecs-execution.id
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "task-policy" {
+  statement {
+    actions   = ["cloudwatch:putMetricData"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "task-assume-role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["ecs-tasks.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "task-execution" {
+  name               = "${var.service_name}-TaskRole-role"
+  assume_role_policy = data.aws_iam_policy_document.task-assume-role.json
+}
+
+resource "aws_iam_role_policy" "task-role" {
+  policy = data.aws_iam_policy_document.task-policy.json
+  role   = aws_iam_role.task-execution.id
+}

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -36,7 +36,6 @@ variable "ecs_memory" {
 variable "container_definitions" {
   description = "Custom container definitions that will be merged with the base definitions"
   default     = {}
-  type        = object
 }
 
 variable "webservice" {

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -1,0 +1,46 @@
+variable "service_name" {
+  description = "The name of the service"
+  type        = string
+}
+
+variable "container_image" {
+  description = "The container image (without the tag to use)"
+  type        = string
+}
+
+
+variable "launch_type" {
+  description = "The launch type to use for the deployment"
+  default     = "FARGATE"
+  type        = string
+}
+
+variable "region" {
+  description = "The AWS region for the deployment"
+  default     = "us-east-1"
+  type        = string
+}
+
+variable "ecs_cpu" {
+  description = "CPU resource allocation"
+  default     = 512
+  type        = number
+}
+
+variable "ecs_memory" {
+  description = "Memory resource allocation"
+  default     = 1024
+  type        = number
+}
+
+variable "container_definitions" {
+  description = "Custom container definitions that will be merged with the base definitions"
+  default     = {}
+  type        = object
+}
+
+variable "webservice" {
+  description = "Boolean to to disable ecs service creation, as this is handled in the webservice module"
+  default     = false
+  type        = bool
+}

--- a/.modules/webservice/dns.tf
+++ b/.modules/webservice/dns.tf
@@ -1,0 +1,12 @@
+data "cloudflare_zone" "dns_zone" {
+  name = var.domain_name
+}
+
+resource "cloudflare_record" "instance_dns" {
+  zone_id = data.cloudflare_zone.dns_zone.id
+  name    = coalesce(var.subdomain, lower(var.service_name))
+  value   = aws_alb.main.dns_name
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+}

--- a/.modules/webservice/ecs.tf
+++ b/.modules/webservice/ecs.tf
@@ -1,0 +1,26 @@
+resource "aws_ecs_service" "webservice" {
+  name                               = var.service_name
+  cluster                            = data.tfe_outputs.infrastructure.values[var.region].ecs_cluster
+  task_definition                    = module.webservice.task_definition
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 200
+  health_check_grace_period_seconds  = 90
+  launch_type                        = var.launch_type
+
+  network_configuration {
+    subnets         = data.tfe_outputs.infrastructure.values[var.region].private_subnets
+    security_groups = [aws_security_group.container_sg.id]
+  }
+
+  depends_on = [
+    aws_lb_target_group.internal,
+    aws_lb_listener.front_end,
+  ]
+
+  load_balancer {
+    container_name   = lower(var.service_name)
+    container_port   = var.port
+    target_group_arn = aws_lb_target_group.internal.arn
+  }
+}

--- a/.modules/webservice/module.tf
+++ b/.modules/webservice/module.tf
@@ -1,0 +1,24 @@
+data "tfe_outputs" "infrastructure" {
+  organization = "home_assistant"
+  workspace    = "infrastructure"
+}
+
+module "webservice" {
+  source = "../service"
+
+  service_name    = var.service_name
+  container_image = var.container_image
+  launch_type     = var.launch_type
+  region          = var.region
+  ecs_cpu         = var.ecs_cpu
+  ecs_memory      = var.ecs_memory
+  webservice      = true
+  container_definitions = merge({
+    portMappings = [
+      {
+        containerPort = var.port
+        hostPort      = var.port
+      }
+    ],
+  }, var.container_definitions)
+}

--- a/.modules/webservice/network.tf
+++ b/.modules/webservice/network.tf
@@ -1,0 +1,92 @@
+resource "aws_security_group" "lb_sg" {
+  vpc_id = data.tfe_outputs.infrastructure.values[var.region].network_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS traffic"
+    from_port   = 443
+    protocol    = "tcp"
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Region = var.region
+    Zone   = "public"
+  }
+}
+
+resource "aws_security_group" "container_sg" {
+  vpc_id = data.tfe_outputs.infrastructure.values[var.region].network_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Web traffic"
+    from_port   = var.port
+    protocol    = "tcp"
+    to_port     = var.port
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Region = var.region
+    Zone   = "private"
+  }
+}
+
+resource "aws_alb" "main" {
+  name               = var.service_name
+  internal           = false
+  load_balancer_type = "application"
+
+  security_groups = [aws_security_group.lb_sg.id]
+  subnets         = data.tfe_outputs.infrastructure.values[var.region].public_subnets
+
+  idle_timeout = "60"
+
+  tags = {
+    Region = var.region
+    Zone   = "public"
+  }
+}
+
+resource "aws_lb_listener" "front_end" {
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.internal.arn
+  }
+
+  load_balancer_arn = aws_alb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = data.tfe_outputs.infrastructure.values.certification_arn
+
+  depends_on = [
+    aws_lb_target_group.internal,
+    aws_alb.main,
+  ]
+}
+
+resource "aws_lb_target_group" "internal" {
+  port                 = var.port
+  protocol             = "HTTP"
+  vpc_id               = data.tfe_outputs.infrastructure.values[var.region].network_id
+  target_type          = "ip"
+  deregistration_delay = 600
+
+  tags = {
+    Region = var.region
+  }
+}

--- a/.modules/webservice/variables.tf
+++ b/.modules/webservice/variables.tf
@@ -1,0 +1,56 @@
+variable "domain_name" {
+  description = "The base domain name"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "The subdomain for the sercive, leave blank to use the service_name variable for it."
+  default     = ""
+  type        = string
+}
+
+variable "service_name" {
+  description = "The name of the service"
+  type        = string
+}
+
+
+variable "container_image" {
+  description = "The container image (without the tag to use)"
+  type        = string
+}
+
+variable "launch_type" {
+  description = "The launch type to use for the deployment"
+  default     = "FARGATE"
+  type        = string
+}
+
+variable "region" {
+  description = "The AWS region for the deployment"
+  default     = "us-east-1"
+  type        = string
+}
+
+variable "ecs_cpu" {
+  description = "CPU resource allocation"
+  default     = 512
+  type        = number
+}
+
+variable "ecs_memory" {
+  description = "Memory resource allocation"
+  default     = 1024
+  type        = number
+}
+
+variable "port" {
+  description = "The port for the webservice"
+  type        = number
+}
+
+variable "container_definitions" {
+  description = "Custom container definitions that will be merged with the base definitions"
+  default     = {}
+  type        = object
+}

--- a/.modules/webservice/variables.tf
+++ b/.modules/webservice/variables.tf
@@ -52,5 +52,4 @@ variable "port" {
 variable "container_definitions" {
   description = "Custom container definitions that will be merged with the base definitions"
   default     = {}
-  type        = object
 }

--- a/.modules/webservice/versions.tf
+++ b/.modules/webservice/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
With this, we are able to deploy services with little code in dedicated deployments
```tf
> ./example/main.tf

terraform {
  cloud {
    organization = "home_assistant"

    workspaces {
      name = "example"
    }
  }

  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 3.0"
    }

    cloudflare = {
      source  = "cloudflare/cloudflare"
      version = "~> 3.0"
    }
  }
}

provider "aws" {
  region = "us-east-1"
}

module "example" {
  source       = "../.modules/webservice"

  service_name = "Example"
  domain_name = var.domain_name
  container_image = "nginx"
  port = 80
}



> ./versions.yml
example: "1.2.3"

```