### PR TITLE
feat(community): add discourse server

### DIFF
--- a/community/ec2.tf
+++ b/community/ec2.tf
@@ -2,4 +2,10 @@
 resource "aws_instance" "discourse" {
   ami           = "ami-003634241a8fcdec0"
   instance_type = "m5a.4xlarge"
+  tags = {
+    "Name" = "Discourse"
+  }
+  tags_all = {
+    "Name" = "Discourse"
+  }
 }

--- a/community/ec2.tf
+++ b/community/ec2.tf
@@ -3,9 +3,9 @@ resource "aws_instance" "discourse" {
   ami           = "ami-003634241a8fcdec0"
   instance_type = "m5a.4xlarge"
   tags = {
-    "Name" = "Discourse"
+    Name = "Discourse"
   }
   tags_all = {
-    "Name" = "Discourse"
+    Name = "Discourse"
   }
 }

--- a/community/ec2.tf
+++ b/community/ec2.tf
@@ -1,0 +1,5 @@
+
+resource "aws_instance" "discourse" {
+  ami           = "ami-003634241a8fcdec0"
+  instance_type = "m5a.4xlarge"
+}

--- a/community/main.tf
+++ b/community/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  cloud {
+    organization = "home_assistant"
+
+    workspaces {
+      name = "community"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_instance" "discourse" {
+  id            = "i-0f10391ee5e9b9527"
+  ami           = "ami-003634241a8fcdec0"
+  instance_type = "m5a.4xlarge"
+}

--- a/community/main.tf
+++ b/community/main.tf
@@ -18,8 +18,3 @@ terraform {
 provider "aws" {
   region = "us-west-2"
 }
-
-resource "aws_instance" "discourse" {
-  ami           = "ami-003634241a8fcdec0"
-  instance_type = "m5a.4xlarge"
-}

--- a/community/main.tf
+++ b/community/main.tf
@@ -20,7 +20,6 @@ provider "aws" {
 }
 
 resource "aws_instance" "discourse" {
-  id            = "i-0f10391ee5e9b9527"
   ami           = "ami-003634241a8fcdec0"
   instance_type = "m5a.4xlarge"
 }


### PR DESCRIPTION
The server has been imported using `terraform import`
The TF state is here: https://app.terraform.io/app/home_assistant/workspaces/community/states/sv-9JutSA8VbpeB8Qn9

I didn't run `terraform apply`; I'm waiting for TF and PR to be reviewed.