### PR TITLE
Add community server elastic IP

### DIFF
--- a/community/dns.tf
+++ b/community/dns.tf
@@ -1,3 +1,7 @@
+data "cloudflare_zone" "dns_zone" {
+  name = var.domain_name
+}
+
 resource "cloudflare_record" "community" {
   zone_id = data.cloudflare_zone.dns_zone.id
   name    = "community"
@@ -13,4 +17,3 @@ resource "cloudflare_record" "community_direct" {
   type    = "A"
   proxied = false
 }
-

--- a/community/dns.tf
+++ b/community/dns.tf
@@ -9,11 +9,3 @@ resource "cloudflare_record" "community" {
   type    = "A"
   proxied = true
 }
-
-resource "cloudflare_record" "community_direct" {
-  zone_id = data.cloudflare_zone.dns_zone.id
-  name    = "community-direct"
-  value   = aws_eip.discourse.public_ip
-  type    = "A"
-  proxied = false
-}

--- a/community/dns.tf
+++ b/community/dns.tf
@@ -1,0 +1,16 @@
+resource "cloudflare_record" "community" {
+  zone_id = data.cloudflare_zone.dns_zone.id
+  name    = "community"
+  value   = aws_eip.discourse.public_ip
+  type    = "A"
+  proxied = true
+}
+
+resource "cloudflare_record" "community_direct" {
+  zone_id = data.cloudflare_zone.dns_zone.id
+  name    = "community-direct"
+  value   = aws_eip.discourse.public_ip
+  type    = "A"
+  proxied = false
+}
+

--- a/community/ec2.tf
+++ b/community/ec2.tf
@@ -6,3 +6,8 @@ resource "aws_instance" "discourse" {
     Name = "Discourse"
   }
 }
+
+resource "aws_eip" "discourse" {
+  instance = aws_instance.discourse.id
+  vpc      = true
+}

--- a/community/ec2.tf
+++ b/community/ec2.tf
@@ -5,7 +5,4 @@ resource "aws_instance" "discourse" {
   tags = {
     Name = "Discourse"
   }
-  tags_all = {
-    Name = "Discourse"
-  }
 }

--- a/community/main.tf
+++ b/community/main.tf
@@ -23,7 +23,3 @@ terraform {
 provider "aws" {
   region = "us-west-2"
 }
-
-data "cloudflare_zone" "dns_zone" {
-  name = var.domain_name
-}

--- a/community/main.tf
+++ b/community/main.tf
@@ -12,9 +12,18 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.0"
     }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
   }
 }
 
 provider "aws" {
   region = "us-west-2"
+}
+
+data "cloudflare_zone" "dns_zone" {
+  name = var.domain_name
 }

--- a/community/variables.tf
+++ b/community/variables.tf
@@ -1,0 +1,4 @@
+variable "domain_name" {
+  description = "The base domain name"
+  type        = string
+}


### PR DESCRIPTION
Attach an Elastic IP to EC2 instance and update Cloudflare DNS.

I imported Cloudflare A records for community and community-direct.

⚠️ When it will be applied IP will be changed, **discourse maintenance should be scheduled before**.

AAAA records still need to be handled.