### PR TITLE
Bump private demo to 2023.2.2.1

### DIFF
--- a/private_demo/main.tf
+++ b/private_demo/main.tf
@@ -34,7 +34,7 @@ module "webservice_private_demo" {
 
   service_name      = "Private-Demo"
   container_image   = "ghcr.io/home-assistant/private-demo"
-  container_version = "2022.10.3"
+  container_version = "2023.2.2.1"
   port              = 8123
 
   container_volumes = [


### PR DESCRIPTION
This is Home Assistant 2023.2.2
the extra .1 is for this change <https://github.com/home-assistant/private-demo/pull/13>