### PR TITLE
Add assist test bucket

### DIFF
--- a/assist/bucket.tf
+++ b/assist/bucket.tf
@@ -3,3 +3,9 @@ resource "cloudflare_r2_bucket" "assist_wakeword_training_data" {
   name       = "assist-wakeword-training-data"
   location   = "ENAM"
 }
+
+resource "cloudflare_r2_bucket" "assist_wakeword_training_data_test" {
+  account_id = var.CLOUDFLARE_ACCOUNT_ID
+  name       = "assist-wakeword-training-data-test"
+  location   = "ENAM"
+}


### PR DESCRIPTION
Add a test bucket for assist wake word, this is useful for the development of the handler not to mess up the dataset.
This is only intended for code development. The dev site should still use the same