### PR TITLE
Revert "Add support for additional deployment regions"

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -18,17 +18,3 @@ module "us_east_1" {
   ecs_policy   = aws_iam_instance_profile.ecs_instance_profile.arn
   network_cidr = var.network_cidr["us-east-1"]
 }
-
-module "eu_central_1" {
-  source       = "./region"
-  region       = "eu-central-1"
-  ecs_policy   = aws_iam_instance_profile.ecs_instance_profile.arn
-  network_cidr = var.network_cidr["eu-central-1"]
-}
-
-module "ap_southeast_1" {
-  source       = "./region"
-  region       = "ap-southeast-1"
-  ecs_policy   = aws_iam_instance_profile.ecs_instance_profile.arn
-  network_cidr = var.network_cidr["ap-southeast-1"]
-}

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -12,23 +12,3 @@ output "us-east-1" {
     "network_id" : module.us_east_1.network_id,
   }
 }
-
-output "eu-central-1" {
-  description = "Outputs for the eu-central-1 region"
-  value = {
-    "public_subnets" : module.eu_central_1.public_subnets,
-    "private_subnets" : module.eu_central_1.private_subnets,
-    "ecs_cluster" : module.eu_central_1.ecs_cluster,
-    "network_id" : module.eu_central_1.network_id,
-  }
-}
-
-output "ap-southeast-1" {
-  description = "Outputs for the ap-southeast-1 region"
-  value = {
-    "public_subnets" : module.ap_southeast_1.public_subnets,
-    "private_subnets" : module.ap_southeast_1.private_subnets,
-    "ecs_cluster" : module.ap_southeast_1.ecs_cluster,
-    "network_id" : module.ap_southeast_1.network_id,
-  }
-}


### PR DESCRIPTION
Reverts home-assistant/deployments#88

This is required for proper Terraform execution; otherwise, it thinks the resources are already there and ignores the fact that they are in different regions.