### PR TITLE
Remove cas_validator related config

### DIFF
--- a/cas_validator/main.tf
+++ b/cas_validator/main.tf
@@ -6,41 +6,4 @@ terraform {
       name = "cas_validator"
     }
   }
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.0"
-    }
-
-    cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "~> 3.0"
-    }
-  }
-}
-
-provider "aws" {
-  region = "us-east-1"
-}
-
-module "webservice_cas_validator" {
-  source = "../.modules/webservice"
-
-  service_name      = "CAS-Validator"
-  subdomain         = "cas-validator"
-  container_image   = "codenotary/immuproof"
-  container_version = "v0.0.11"
-  port              = 8091
-
-  container_definitions = {
-    environment : [
-      { name : "IMMUPROOF_HOST", value : "cas.codenotary.com" },
-      { name : "IMMUPROOF_PORT", value : "443" },
-      { name : "IMMUPROOF_API_KEY", value : var.cas_api_key },
-      { name : "IMMUPROOF_WEB_TITLE_TEXT", value : "Home Assistant service validator" },
-      { name : "IMMUPROOF_WEB_HOSTED_BY_TEXT", value : "Home Assistant Community" },
-      { name : "IMMUPROOF_WEB_HOSTED_BY_LOGO_URL", value : "https://www.home-assistant.io/images/home-assistant-logo.svg" }
-    ]
-  }
 }

--- a/cas_validator/variables.tf
+++ b/cas_validator/variables.tf
@@ -1,4 +1,0 @@
-variable "cas_api_key" {
-  description = "CAS Key for monitoring the immodb"
-  type        = string
-}


### PR DESCRIPTION
As CAS Validator is not used anymore, it is being removed.

After this is merged, we can queue a destroy plan in Terraform.