### PR TITLE
Modify service module to support external ECS execution and task roles

### DIFF
--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -20,8 +20,8 @@ resource "aws_ecs_task_definition" "task" {
   family                   = var.service_name
   cpu                      = var.ecs_cpu
   memory                   = var.ecs_memory
-  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, list(var.ecs_execution_role_arn)), var.ecs_execution_role_arn == "" ? 0 : 1)
-  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, list(var.ecs_task_execution_role_arn)), var.ecs_task_execution_role_arn == "" ? 0 : 1)
+  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, tolist([var.ecs_execution_role_arn])), var.ecs_execution_role_arn == "" ? 0 : 1)
+  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, tolist([var.ecs_task_execution_role_arn])), var.ecs_task_execution_role_arn == "" ? 0 : 1)
   network_mode             = "awsvpc"
   requires_compatibilities = [var.launch_type]
 

--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -20,8 +20,8 @@ resource "aws_ecs_task_definition" "task" {
   family                   = var.service_name
   cpu                      = var.ecs_cpu
   memory                   = var.ecs_memory
-  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, data.aws_iam_role.ecs-execution-external.*.arn), var.create_policies ? 0 : 1)
-  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, data.aws_iam_role.task-execution-external.*.arn), var.create_policies ? 0 : 1)
+  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, data.aws_iam_role.ecs-execution-external.*.arn), var.external_ecs_execution_role == "" ? 0 : 1)
+  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, data.aws_iam_role.task-execution-external.*.arn), var.external_ecs_task_execution_role == "" ? 0 : 1)
   network_mode             = "awsvpc"
   requires_compatibilities = [var.launch_type]
 

--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -20,8 +20,8 @@ resource "aws_ecs_task_definition" "task" {
   family                   = var.service_name
   cpu                      = var.ecs_cpu
   memory                   = var.ecs_memory
-  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, tolist([var.external_ecs_execution_role_arn])), var.create_policies ? 0 : 1)
-  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, tolist([var.external_ecs_task_execution_role_arn])), var.create_policies ? 0 : 1)
+  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, data.aws_iam_role.ecs-execution-external.*.arn), var.create_policies ? 0 : 1)
+  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, data.aws_iam_role.task-execution-external.*.arn), var.create_policies ? 0 : 1)
   network_mode             = "awsvpc"
   requires_compatibilities = [var.launch_type]
 

--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -20,8 +20,8 @@ resource "aws_ecs_task_definition" "task" {
   family                   = var.service_name
   cpu                      = var.ecs_cpu
   memory                   = var.ecs_memory
-  execution_role_arn       = coalesce(var.ecs_execution_role_arn, aws_iam_role.ecs-execution.arn)
-  task_role_arn            = coalesce(var.ecs_task_execution_role_arn, aws_iam_role.task-execution.arn)
+  execution_role_arn       = var.ecs_execution_role_arn != "" ? var.ecs_execution_role_arn : aws_iam_role.ecs-execution.arn
+  task_role_arn            = var.ecs_task_execution_role_arn != "" ? var.ecs_task_execution_role_arn : aws_iam_role.task-execution.arn
   network_mode             = "awsvpc"
   requires_compatibilities = [var.launch_type]
 

--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -20,8 +20,8 @@ resource "aws_ecs_task_definition" "task" {
   family                   = var.service_name
   cpu                      = var.ecs_cpu
   memory                   = var.ecs_memory
-  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, tolist([var.ecs_execution_role_arn])), var.ecs_execution_role_arn == "" ? 0 : 1)
-  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, tolist([var.ecs_task_execution_role_arn])), var.ecs_task_execution_role_arn == "" ? 0 : 1)
+  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, tolist([var.ecs_execution_role_arn])), var.create_policy ? 0 : 1)
+  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, tolist([var.ecs_task_execution_role_arn])), var.create_policy ? 0 : 1)
   network_mode             = "awsvpc"
   requires_compatibilities = [var.launch_type]
 

--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -20,8 +20,8 @@ resource "aws_ecs_task_definition" "task" {
   family                   = var.service_name
   cpu                      = var.ecs_cpu
   memory                   = var.ecs_memory
-  execution_role_arn       = aws_iam_role.ecs-execution.arn
-  task_role_arn            = aws_iam_role.task-execution.arn
+  execution_role_arn       = coalesce(var.ecs_execution_role_arn, aws_iam_role.ecs-execution.arn)
+  task_role_arn            = coalesce(var.ecs_task_execution_role_arn, aws_iam_role.task-execution.arn)
   network_mode             = "awsvpc"
   requires_compatibilities = [var.launch_type]
 

--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -20,8 +20,8 @@ resource "aws_ecs_task_definition" "task" {
   family                   = var.service_name
   cpu                      = var.ecs_cpu
   memory                   = var.ecs_memory
-  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, tolist([var.ecs_execution_role_arn])), var.create_policy ? 0 : 1)
-  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, tolist([var.ecs_task_execution_role_arn])), var.create_policy ? 0 : 1)
+  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, tolist([var.external_ecs_execution_role_arn])), var.create_policies ? 0 : 1)
+  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, tolist([var.external_ecs_task_execution_role_arn])), var.create_policies ? 0 : 1)
   network_mode             = "awsvpc"
   requires_compatibilities = [var.launch_type]
 

--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -20,8 +20,8 @@ resource "aws_ecs_task_definition" "task" {
   family                   = var.service_name
   cpu                      = var.ecs_cpu
   memory                   = var.ecs_memory
-  execution_role_arn       = var.ecs_execution_role_arn != "" ? var.ecs_execution_role_arn : aws_iam_role.ecs-execution.arn
-  task_role_arn            = var.ecs_task_execution_role_arn != "" ? var.ecs_task_execution_role_arn : aws_iam_role.task-execution.arn
+  execution_role_arn       = element(concat(aws_iam_role.ecs-execution.*.arn, list(var.ecs_execution_role_arn)), var.ecs_execution_role_arn == "" ? 0 : 1)
+  task_role_arn            = element(concat(aws_iam_role.task-execution.*.arn, list(var.ecs_task_execution_role_arn)), var.ecs_task_execution_role_arn == "" ? 0 : 1)
   network_mode             = "awsvpc"
   requires_compatibilities = [var.launch_type]
 

--- a/.modules/service/policy.tf
+++ b/.modules/service/policy.tf
@@ -10,16 +10,16 @@ data "aws_iam_policy_document" "ecs-role-policy" {
 }
 
 resource "aws_iam_role" "ecs-execution" {
-  count = var.ecs_execution_role_arn == "" ? 1 : 0
+  count = var.create_policy ? 1 : 0
 
   name               = "${var.service_name}-ExecutionRole-role"
   assume_role_policy = data.aws_iam_policy_document.ecs-role-policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-execution-managed" {
-  count = var.ecs_execution_role_arn == "" ? 1 : 0
+  count = var.create_policy ? 1 : 0
 
-  role       = element(concat(aws_iam_role.ecs-execution.*.id, tolist([""])), var.ecs_execution_role_arn == "" ? 0 : 1)
+  role       = element(concat(aws_iam_role.ecs-execution.*.id, tolist([""])), var.create_policy ? 0 : 1)
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
@@ -50,15 +50,15 @@ data "aws_iam_policy_document" "task-assume-role" {
 }
 
 resource "aws_iam_role" "task-execution" {
-  count = var.ecs_task_execution_role_arn == "" ? 1 : 0
+  count = var.create_policy ? 1 : 0
 
   name               = "${var.service_name}-TaskRole-role"
   assume_role_policy = data.aws_iam_policy_document.task-assume-role.json
 }
 
 resource "aws_iam_role_policy" "task-role" {
-  count = var.ecs_task_execution_role_arn == "" ? 1 : 0
+  count = var.create_policy ? 1 : 0
 
   policy = data.aws_iam_policy_document.task-policy.json
-  role   = element(concat(aws_iam_role.task-execution.*.id, tolist([""])), var.ecs_task_execution_role_arn == "" ? 0 : 1)
+  role   = element(concat(aws_iam_role.task-execution.*.id, tolist([""])), var.create_policy ? 0 : 1)
 }

--- a/.modules/service/policy.tf
+++ b/.modules/service/policy.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role" "ecs-execution" {
 resource "aws_iam_role_policy_attachment" "ecs-execution-managed" {
   count = var.ecs_execution_role_arn == "" ? 1 : 0
 
-  role       = aws_iam_role.ecs-execution.id
+  role       = var.ecs_execution_role_arn == "" ? aws_iam_role.ecs-execution.id : ""
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
@@ -60,5 +60,5 @@ resource "aws_iam_role_policy" "task-role" {
   count = var.ecs_task_execution_role_arn == "" ? 1 : 0
 
   policy = data.aws_iam_policy_document.task-policy.json
-  role   = aws_iam_role.task-execution.id
+  role   = var.ecs_task_execution_role_arn == "" ? aws_iam_role.task-execution.id : ""
 }

--- a/.modules/service/policy.tf
+++ b/.modules/service/policy.tf
@@ -10,16 +10,16 @@ data "aws_iam_policy_document" "ecs-role-policy" {
 }
 
 resource "aws_iam_role" "ecs-execution" {
-  count = var.create_policies ? 1 : 0
+  count = var.external_ecs_execution_role == "" ? 1 : 0
 
   name               = "${var.service_name}-ExecutionRole-role"
   assume_role_policy = data.aws_iam_policy_document.ecs-role-policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-execution-managed" {
-  count = var.create_policies ? 1 : 0
+  count = var.external_ecs_execution_role == "" ? 1 : 0
 
-  role       = element(concat(aws_iam_role.ecs-execution.*.id, tolist([""])), var.create_policies ? 0 : 1)
+  role       = element(concat(aws_iam_role.ecs-execution.*.id, tolist([""])), var.external_ecs_execution_role == "" ? 0 : 1)
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
@@ -50,27 +50,27 @@ data "aws_iam_policy_document" "task-assume-role" {
 }
 
 resource "aws_iam_role" "task-execution" {
-  count = var.create_policies ? 1 : 0
+  count = var.external_ecs_task_execution_role == "" ? 1 : 0
 
   name               = "${var.service_name}-TaskRole-role"
   assume_role_policy = data.aws_iam_policy_document.task-assume-role.json
 }
 
 resource "aws_iam_role_policy" "task-role" {
-  count = var.create_policies ? 1 : 0
+  count = var.external_ecs_task_execution_role == "" ? 1 : 0
 
   policy = data.aws_iam_policy_document.task-policy.json
-  role   = element(concat(aws_iam_role.task-execution.*.id, tolist([""])), var.create_policies ? 0 : 1)
+  role   = element(concat(aws_iam_role.task-execution.*.id, tolist([""])), var.external_ecs_task_execution_role == "" ? 0 : 1)
 }
 
 data "aws_iam_role" "ecs-execution-external" {
-  count = var.create_policies ? 0 : 1
+  count = var.external_ecs_execution_role == "" ? 0 : 1
 
   name = var.external_ecs_execution_role
 }
 
 data "aws_iam_role" "task-execution-external" {
-  count = var.create_policies ? 0 : 1
+  count = var.external_ecs_task_execution_role == "" ? 0 : 1
 
   name = var.external_ecs_task_execution_role
 }

--- a/.modules/service/policy.tf
+++ b/.modules/service/policy.tf
@@ -10,16 +10,16 @@ data "aws_iam_policy_document" "ecs-role-policy" {
 }
 
 resource "aws_iam_role" "ecs-execution" {
-  count = var.create_policy ? 1 : 0
+  count = var.create_policies ? 1 : 0
 
   name               = "${var.service_name}-ExecutionRole-role"
   assume_role_policy = data.aws_iam_policy_document.ecs-role-policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-execution-managed" {
-  count = var.create_policy ? 1 : 0
+  count = var.create_policies ? 1 : 0
 
-  role       = element(concat(aws_iam_role.ecs-execution.*.id, tolist([""])), var.create_policy ? 0 : 1)
+  role       = element(concat(aws_iam_role.ecs-execution.*.id, tolist([""])), var.create_policies ? 0 : 1)
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
@@ -50,15 +50,15 @@ data "aws_iam_policy_document" "task-assume-role" {
 }
 
 resource "aws_iam_role" "task-execution" {
-  count = var.create_policy ? 1 : 0
+  count = var.create_policies ? 1 : 0
 
   name               = "${var.service_name}-TaskRole-role"
   assume_role_policy = data.aws_iam_policy_document.task-assume-role.json
 }
 
 resource "aws_iam_role_policy" "task-role" {
-  count = var.create_policy ? 1 : 0
+  count = var.create_policies ? 1 : 0
 
   policy = data.aws_iam_policy_document.task-policy.json
-  role   = element(concat(aws_iam_role.task-execution.*.id, tolist([""])), var.create_policy ? 0 : 1)
+  role   = element(concat(aws_iam_role.task-execution.*.id, tolist([""])), var.create_policies ? 0 : 1)
 }

--- a/.modules/service/policy.tf
+++ b/.modules/service/policy.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role" "ecs-execution" {
 resource "aws_iam_role_policy_attachment" "ecs-execution-managed" {
   count = var.ecs_execution_role_arn == "" ? 1 : 0
 
-  role       = var.ecs_execution_role_arn == "" ? aws_iam_role.ecs-execution.id : ""
+  role       = element(concat(aws_iam_role.ecs-execution.*.id, list("")), var.ecs_execution_role_arn == "" ? 0 : 1)
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
@@ -60,5 +60,5 @@ resource "aws_iam_role_policy" "task-role" {
   count = var.ecs_task_execution_role_arn == "" ? 1 : 0
 
   policy = data.aws_iam_policy_document.task-policy.json
-  role   = var.ecs_task_execution_role_arn == "" ? aws_iam_role.task-execution.id : ""
+  role   = element(concat(aws_iam_role.task-execution.*.id, list("")), var.ecs_task_execution_role_arn == "" ? 0 : 1)
 }

--- a/.modules/service/policy.tf
+++ b/.modules/service/policy.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role" "ecs-execution" {
 resource "aws_iam_role_policy_attachment" "ecs-execution-managed" {
   count = var.ecs_execution_role_arn == "" ? 1 : 0
 
-  role       = element(concat(aws_iam_role.ecs-execution.*.id, list("")), var.ecs_execution_role_arn == "" ? 0 : 1)
+  role       = element(concat(aws_iam_role.ecs-execution.*.id, tolist([""])), var.ecs_execution_role_arn == "" ? 0 : 1)
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
@@ -60,5 +60,5 @@ resource "aws_iam_role_policy" "task-role" {
   count = var.ecs_task_execution_role_arn == "" ? 1 : 0
 
   policy = data.aws_iam_policy_document.task-policy.json
-  role   = element(concat(aws_iam_role.task-execution.*.id, list("")), var.ecs_task_execution_role_arn == "" ? 0 : 1)
+  role   = element(concat(aws_iam_role.task-execution.*.id, tolist([""])), var.ecs_task_execution_role_arn == "" ? 0 : 1)
 }

--- a/.modules/service/policy.tf
+++ b/.modules/service/policy.tf
@@ -62,3 +62,15 @@ resource "aws_iam_role_policy" "task-role" {
   policy = data.aws_iam_policy_document.task-policy.json
   role   = element(concat(aws_iam_role.task-execution.*.id, tolist([""])), var.create_policies ? 0 : 1)
 }
+
+data "aws_iam_role" "ecs-execution-external" {
+  count = var.create_policies ? 0 : 1
+
+  name = var.external_ecs_execution_role
+}
+
+data "aws_iam_role" "task-execution-external" {
+  count = var.create_policies ? 0 : 1
+
+  name = var.external_ecs_task_execution_role
+}

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -66,20 +66,20 @@ variable "rolling_updates" {
   type        = bool
 }
 
-variable "create_policy" {
-  description = "Boolean to create the policy"
+variable "create_policies" {
+  description = "Boolean whether to create the policy"
   default     = true
   type        = bool
 }
 
-variable "ecs_execution_role_arn" {
-  description = "The ARN of the ECS execution role"
+variable "external_ecs_execution_role_arn" {
+  description = "The ARN of an external ECS execution role to use"
   type        = string
   default     = ""
 }
 
-variable "ecs_task_execution_role_arn" {
-  description = "The ARN of the ECS task role"
+variable "external_ecs_task_execution_role_arn" {
+  description = "The ARN of an external ECS task execution role to use"
   type        = string
   default     = ""
 }

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -66,12 +66,6 @@ variable "rolling_updates" {
   type        = bool
 }
 
-variable "create_policies" {
-  description = "Boolean whether to create the policy"
-  default     = true
-  type        = bool
-}
-
 variable "external_ecs_execution_role" {
   description = "The name of an external ECS execution role to use"
   type        = string

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -72,14 +72,14 @@ variable "create_policies" {
   type        = bool
 }
 
-variable "external_ecs_execution_role_arn" {
-  description = "The ARN of an external ECS execution role to use"
+variable "external_ecs_execution_role" {
+  description = "The name of an external ECS execution role to use"
   type        = string
   default     = ""
 }
 
-variable "external_ecs_task_execution_role_arn" {
-  description = "The ARN of an external ECS task execution role to use"
+variable "external_ecs_task_execution_role" {
+  description = "The name of an external ECS task execution role to use"
   type        = string
   default     = ""
 }

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -65,3 +65,15 @@ variable "rolling_updates" {
   default     = false
   type        = bool
 }
+
+variable "ecs_execution_role_arn" {
+  description = "The ARN of the ECS execution role"
+  type        = string
+  default     = ""
+}
+
+variable "ecs_task_execution_role_arn" {
+  description = "The ARN of the ECS task role"
+  type        = string
+  default     = ""
+}

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -66,6 +66,12 @@ variable "rolling_updates" {
   type        = bool
 }
 
+variable "create_policy" {
+  description = "Boolean to create the policy"
+  default     = true
+  type        = bool
+}
+
 variable "ecs_execution_role_arn" {
   description = "The ARN of the ECS execution role"
   type        = string

--- a/stun_server/main.tf
+++ b/stun_server/main.tf
@@ -15,23 +15,29 @@ provider "aws" {
 module "us_east_1" {
   source = "./region"
 
-  region      = "us-east-1"
-  domain_name = var.domain_name
-  image_tag   = var.image_tag
+  region                      = "us-east-1"
+  domain_name                 = var.domain_name
+  image_tag                   = var.image_tag
+  ecs_execution_role_arn      = aws_iam_role.ecs-execution.arn
+  ecs_task_execution_role_arn = aws_iam_role.task-execution.arn
 }
 
 module "eu_central_1" {
   source = "./region"
 
-  region      = "eu-central-1"
-  domain_name = var.domain_name
-  image_tag   = var.image_tag
+  region                      = "eu-central-1"
+  domain_name                 = var.domain_name
+  image_tag                   = var.image_tag
+  ecs_execution_role_arn      = aws_iam_role.ecs-execution.arn
+  ecs_task_execution_role_arn = aws_iam_role.task-execution.arn
 }
 
 module "ap_southeast_1" {
   source = "./region"
 
-  region      = "ap-southeast-1"
-  domain_name = var.domain_name
-  image_tag   = var.image_tag
+  region                      = "ap-southeast-1"
+  domain_name                 = var.domain_name
+  image_tag                   = var.image_tag
+  ecs_execution_role_arn      = aws_iam_role.ecs-execution.arn
+  ecs_task_execution_role_arn = aws_iam_role.task-execution.arn
 }

--- a/stun_server/main.tf
+++ b/stun_server/main.tf
@@ -15,29 +15,29 @@ provider "aws" {
 module "us_east_1" {
   source = "./region"
 
-  region                      = "us-east-1"
-  domain_name                 = var.domain_name
-  image_tag                   = var.image_tag
-  ecs_execution_role_arn      = aws_iam_role.ecs-execution.arn
-  ecs_task_execution_role_arn = aws_iam_role.task-execution.arn
+  region                  = "us-east-1"
+  domain_name             = var.domain_name
+  image_tag               = var.image_tag
+  ecs_execution_role      = aws_iam_role.ecs-execution.name
+  ecs_task_execution_role = aws_iam_role.task-execution.name
 }
 
 module "eu_central_1" {
   source = "./region"
 
-  region                      = "eu-central-1"
-  domain_name                 = var.domain_name
-  image_tag                   = var.image_tag
-  ecs_execution_role_arn      = aws_iam_role.ecs-execution.arn
-  ecs_task_execution_role_arn = aws_iam_role.task-execution.arn
+  region                  = "eu-central-1"
+  domain_name             = var.domain_name
+  image_tag               = var.image_tag
+  ecs_execution_role      = aws_iam_role.ecs-execution.name
+  ecs_task_execution_role = aws_iam_role.task-execution.name
 }
 
 module "ap_southeast_1" {
   source = "./region"
 
-  region                      = "ap-southeast-1"
-  domain_name                 = var.domain_name
-  image_tag                   = var.image_tag
-  ecs_execution_role_arn      = aws_iam_role.ecs-execution.arn
-  ecs_task_execution_role_arn = aws_iam_role.task-execution.arn
+  region                  = "ap-southeast-1"
+  domain_name             = var.domain_name
+  image_tag               = var.image_tag
+  ecs_execution_role      = aws_iam_role.ecs-execution.name
+  ecs_task_execution_role = aws_iam_role.task-execution.name
 }

--- a/stun_server/policy.tf
+++ b/stun_server/policy.tf
@@ -10,14 +10,12 @@ data "aws_iam_policy_document" "ecs-role-policy" {
 }
 
 resource "aws_iam_role" "ecs-execution" {
-  count = var.ecs_execution_role_arn == "" ? 1 : 0
 
-  name               = "${var.service_name}-ExecutionRole-role"
+  name               = "stun-server-ExecutionRole-role"
   assume_role_policy = data.aws_iam_policy_document.ecs-role-policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-execution-managed" {
-  count = var.ecs_execution_role_arn == "" ? 1 : 0
 
   role       = aws_iam_role.ecs-execution.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
@@ -27,14 +25,6 @@ data "aws_iam_policy_document" "task-policy" {
   statement {
     actions   = ["cloudwatch:putMetricData"]
     resources = ["*"]
-  }
-
-  dynamic "statement" {
-    for_each = var.task_policy_statements
-    content {
-      actions   = statement.value["actions"]
-      resources = statement.value["resources"]
-    }
   }
 }
 
@@ -50,14 +40,12 @@ data "aws_iam_policy_document" "task-assume-role" {
 }
 
 resource "aws_iam_role" "task-execution" {
-  count = var.ecs_task_execution_role_arn == "" ? 1 : 0
 
-  name               = "${var.service_name}-TaskRole-role"
+  name               = "stun-server-TaskRole-role"
   assume_role_policy = data.aws_iam_policy_document.task-assume-role.json
 }
 
 resource "aws_iam_role_policy" "task-role" {
-  count = var.ecs_task_execution_role_arn == "" ? 1 : 0
 
   policy = data.aws_iam_policy_document.task-policy.json
   role   = aws_iam_role.task-execution.id

--- a/stun_server/region/ecs.tf
+++ b/stun_server/region/ecs.tf
@@ -5,7 +5,6 @@ resource "aws_ecs_service" "stun-server" {
   desired_count                      = 1
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
-  health_check_grace_period_seconds  = 90
   launch_type                        = "FARGATE"
 
   # Required to fetch the public IP address of the ECS service

--- a/stun_server/region/module.tf
+++ b/stun_server/region/module.tf
@@ -37,8 +37,8 @@ module "stun_server" {
       }
     ],
   }
-  webservice                  = true
-  create_policy               = false
-  ecs_execution_role_arn      = var.ecs_execution_role_arn
-  ecs_task_execution_role_arn = var.ecs_task_execution_role_arn
+  webservice                           = true
+  create_policies                      = false
+  external_ecs_execution_role_arn      = var.ecs_execution_role_arn
+  external_ecs_task_execution_role_arn = var.ecs_task_execution_role_arn
 }

--- a/stun_server/region/module.tf
+++ b/stun_server/region/module.tf
@@ -38,6 +38,7 @@ module "stun_server" {
     ],
   }
   webservice                  = true
+  create_policy               = false
   ecs_execution_role_arn      = var.ecs_execution_role_arn
   ecs_task_execution_role_arn = var.ecs_task_execution_role_arn
 }

--- a/stun_server/region/module.tf
+++ b/stun_server/region/module.tf
@@ -37,8 +37,8 @@ module "stun_server" {
       }
     ],
   }
-  webservice                           = true
-  create_policies                      = false
-  external_ecs_execution_role_arn      = var.ecs_execution_role_arn
-  external_ecs_task_execution_role_arn = var.ecs_task_execution_role_arn
+  webservice                       = true
+  create_policies                  = false
+  external_ecs_execution_role      = var.ecs_execution_role
+  external_ecs_task_execution_role = var.ecs_task_execution_role
 }

--- a/stun_server/region/module.tf
+++ b/stun_server/region/module.tf
@@ -38,7 +38,6 @@ module "stun_server" {
     ],
   }
   webservice                       = true
-  create_policies                  = false
   external_ecs_execution_role      = var.ecs_execution_role
   external_ecs_task_execution_role = var.ecs_task_execution_role
 }

--- a/stun_server/region/module.tf
+++ b/stun_server/region/module.tf
@@ -37,5 +37,7 @@ module "stun_server" {
       }
     ],
   }
-  webservice = true
+  webservice                  = true
+  ecs_execution_role_arn      = var.ecs_execution_role_arn
+  ecs_task_execution_role_arn = var.ecs_task_execution_role_arn
 }

--- a/stun_server/region/variables.tf
+++ b/stun_server/region/variables.tf
@@ -13,12 +13,12 @@ variable "image_tag" {
   type        = string
 }
 
-variable "ecs_execution_role_arn" {
-  description = "The ARN of the ECS execution role"
+variable "ecs_execution_role" {
+  description = "The name of the ECS execution role"
   type        = string
 }
 
-variable "ecs_task_execution_role_arn" {
-  description = "The ARN of the ECS task execution role"
+variable "ecs_task_execution_role" {
+  description = "The name of the ECS task execution role"
   type        = string
 }

--- a/stun_server/region/variables.tf
+++ b/stun_server/region/variables.tf
@@ -12,3 +12,13 @@ variable "image_tag" {
   description = "Version of the Stun server to deploy"
   type        = string
 }
+
+variable "ecs_execution_role_arn" {
+  description = "The ARN of the ECS execution role"
+  type        = string
+}
+
+variable "ecs_task_execution_role_arn" {
+  description = "The ARN of the ECS task execution role"
+  type        = string
+}


### PR DESCRIPTION
This PR modifies the `service` module to support external ECS execution and task roles to be defined for the service and prevent module policy creation. This is useful for services like `stun_server`, which runs in multiple regions, but IAM roles need to be created only in one.

~~I tried defining policy creation in the `service` module (`count` value) based on the role variable values passed to the module; however, because roles have to be created first, Terraform could not determine the actual variable values during the run, and I had to implement a separate `create_policies` variable instead.~~