### PR TITLE
Remove health check grace period from Stun server ECS config

### DIFF
--- a/stun_server/region/ecs.tf
+++ b/stun_server/region/ecs.tf
@@ -5,7 +5,6 @@ resource "aws_ecs_service" "stun-server" {
   desired_count                      = 1
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
-  health_check_grace_period_seconds  = 90
   launch_type                        = "FARGATE"
 
   # Required to fetch the public IP address of the ECS service


### PR DESCRIPTION
As we are not using a load balancer, this is not needed, and Terraform throws an error for having it.
It was added before because it is used by the `webservice` module; however, that module has a load balancer.