### PR TITLE
Disable Cloudflare proxy for Stun server

### DIFF
--- a/stun_server/region/dns.tf
+++ b/stun_server/region/dns.tf
@@ -7,6 +7,7 @@ resource "cloudflare_record" "instance_dns" {
   name       = join("-", ["stun", data.aws_region.current.name])
   content    = data.aws_network_interface.stun_server_interface.association[0].public_ip
   type       = "A"
-  proxied    = true
+  ttl        = 1
+  proxied    = false
   depends_on = [data.aws_network_interface.stun_server_interface]
 }

--- a/stun_server/region/dns.tf
+++ b/stun_server/region/dns.tf
@@ -7,7 +7,7 @@ resource "cloudflare_record" "instance_dns" {
   name       = join("-", ["stun", data.aws_region.current.name])
   content    = data.aws_network_interface.stun_server_interface.association[0].public_ip
   type       = "A"
-  ttl        = 1
+  ttl        = 300
   proxied    = false
   depends_on = [data.aws_network_interface.stun_server_interface]
 }


### PR DESCRIPTION
Stun protocol cannot be proxied through Cloudflare.