### PR TITLE
Delete CAS Validator entirely

### DIFF
--- a/cas_validator/main.tf
+++ b/cas_validator/main.tf
@@ -1,9 +1,0 @@
-terraform {
-  cloud {
-    organization = "home_assistant"
-
-    workspaces {
-      name = "cas_validator"
-    }
-  }
-}


### PR DESCRIPTION
As #105 is merged now, we can delete the whole CAS Validator folder.