### PR TITLE
Add Marketplace Demo 

### DIFF
--- a/marketplace-demo/README.md
+++ b/marketplace-demo/README.md
@@ -1,21 +1,22 @@
-# Private Demo Ephemeral
+# Marketplace Demo
 
-Ephemeral version of the Private Demo deployment. Unlike the standard `private_demo`, this deployment has no persistent storage.
+Ephemeral demo deployment with no persistent storage. The deployed image automatically injects the specified users on startup via the `DEFAULT_USERS` environment variable.
 
 ## Behavior
 
 - **No EFS volume**: Container data is stored in the ephemeral container filesystem
 - **Data loss on restart**: Any configuration or data written to `/config` is lost when the container restarts or redeploys
 - **Weekly reset**: An EventBridge Scheduler forces a new deployment every Sunday at 6am CET, resetting all data
+- **Automatic user injection**: The container injects users from `DEFAULT_USERS` on each startup
 
 ## Use Case
 
-This deployment is intended for temporary demo environments where persistent state is not needed and a clean slate is preferred on a regular basis.
+This deployment is intended for marketplace app validation, providing a temporary demo environment where persistent state is not needed and a clean state is preferred on a regular basis.
 
 ## Files
 
 | File | Description |
 |------|-------------|
 | `main.tf` | ECS service definition using the webservice module |
-| `variables.tf` | Input variables (image tag) |
+| `variables.tf` | Input variables (image tag, default users) |
 | `scheduler.tf` | Weekly reset schedule via EventBridge Scheduler |

--- a/marketplace-demo/README.md
+++ b/marketplace-demo/README.md
@@ -1,0 +1,21 @@
+# Private Demo Ephemeral
+
+Ephemeral version of the Private Demo deployment. Unlike the standard `private_demo`, this deployment has no persistent storage.
+
+## Behavior
+
+- **No EFS volume**: Container data is stored in the ephemeral container filesystem
+- **Data loss on restart**: Any configuration or data written to `/config` is lost when the container restarts or redeploys
+- **Weekly reset**: An EventBridge Scheduler forces a new deployment every Sunday at 6am CET, resetting all data
+
+## Use Case
+
+This deployment is intended for temporary demo environments where persistent state is not needed and a clean slate is preferred on a regular basis.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.tf` | ECS service definition using the webservice module |
+| `variables.tf` | Input variables (image tag) |
+| `scheduler.tf` | Weekly reset schedule via EventBridge Scheduler |

--- a/marketplace-demo/main.tf
+++ b/marketplace-demo/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  cloud {
+    organization = "home_assistant"
+
+    workspaces {
+      name = "marketplace_demo"
+    }
+  }
+
+  required_version = "~> 1.11.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+
+   default_tags {
+    tags = {
+      application = "marketplace-demo"
+    }
+  }
+}
+
+data "tfe_outputs" "infrastructure" {
+  organization = "home_assistant"
+  workspace    = "infrastructure"
+}
+
+module "webservice_marketplace_demo" {
+  source = "../.modules/webservice"
+
+  service_name      = "Marketplace Demo"
+  container_image   = "ghcr.io/OpenHomeFoundation/marketplace-demo"
+  container_version = var.image_tag
+  port              = 8123
+  cloudflare_proxy  = false
+
+  container_definitions = {
+    environment = [
+      {
+        name  = "DEFAULT_USERS"
+        value = var.default_users
+      }
+    ]
+  }
+}

--- a/marketplace-demo/main.tf
+++ b/marketplace-demo/main.tf
@@ -40,7 +40,7 @@ data "tfe_outputs" "infrastructure" {
 module "webservice_marketplace_demo" {
   source = "../.modules/webservice"
 
-  service_name      = "Marketplace Demo"
+  service_name      = "Marketplace-Demo"
   container_image   = "ghcr.io/home-assistant/marketplace-demo"
   container_version = var.image_tag
   port              = 8123

--- a/marketplace-demo/main.tf
+++ b/marketplace-demo/main.tf
@@ -41,7 +41,7 @@ module "webservice_marketplace_demo" {
   source = "../.modules/webservice"
 
   service_name      = "Marketplace Demo"
-  container_image   = "ghcr.io/OpenHomeFoundation/marketplace-demo"
+  container_image   = "ghcr.io/home-assistant/marketplace-demo"
   container_version = var.image_tag
   port              = 8123
   cloudflare_proxy  = false

--- a/marketplace-demo/main.tf
+++ b/marketplace-demo/main.tf
@@ -45,6 +45,7 @@ module "webservice_marketplace_demo" {
   container_version = var.image_tag
   port              = 8123
   cloudflare_proxy  = false
+  ecs_memory        = 3072
 
   container_definitions = {
     environment = [

--- a/marketplace-demo/main.tf
+++ b/marketplace-demo/main.tf
@@ -25,7 +25,7 @@ terraform {
 provider "aws" {
   region = "us-east-1"
 
-   default_tags {
+  default_tags {
     tags = {
       application = "marketplace-demo"
     }

--- a/marketplace-demo/main.tf
+++ b/marketplace-demo/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.11.0"
+  required_version = "~> 1.14.3"
 
   required_providers {
     aws = {

--- a/marketplace-demo/scheduler.tf
+++ b/marketplace-demo/scheduler.tf
@@ -1,0 +1,59 @@
+resource "aws_iam_role" "scheduler" {
+  name = "marketplace-demo-scheduler"
+
+  tags = {
+    Name = "Marketplace-Demo-Scheduler"
+  }
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "scheduler.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "scheduler" {
+  name = "ecs-update-service"
+  role = aws_iam_role.scheduler.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ecs:UpdateService"
+        Resource = "arn:aws:ecs:us-east-1:*:service/*/Marketplace-Demo"
+      }
+    ]
+  })
+}
+
+resource "aws_scheduler_schedule" "weekly_reset" {
+  name       = "marketplace-demo-weekly-reset"
+  group_name = "default"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression          = "cron(0 5 ? * SUN *)"
+  schedule_expression_timezone = "Europe/Paris"
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:ecs:updateService"
+    role_arn = aws_iam_role.scheduler.arn
+
+    input = jsonencode({
+      Cluster            = data.tfe_outputs.infrastructure.values["us-east-1"].ecs_cluster
+      Service            = "Marketplace-Demo"
+      ForceNewDeployment = true
+    })
+  }
+}

--- a/marketplace-demo/scheduler.tf
+++ b/marketplace-demo/scheduler.tf
@@ -20,7 +20,7 @@ resource "aws_iam_role" "scheduler" {
 }
 
 resource "aws_iam_role_policy" "scheduler" {
-  name = "ecs-update-service"
+  name = "marketplace-demo-ecs-update-service"
   role = aws_iam_role.scheduler.id
 
   policy = jsonencode({

--- a/marketplace-demo/scheduler.tf
+++ b/marketplace-demo/scheduler.tf
@@ -43,7 +43,7 @@ resource "aws_scheduler_schedule" "weekly_reset" {
     mode = "OFF"
   }
 
-  schedule_expression          = "cron(0 5 ? * SUN *)"
+  schedule_expression          = "cron(0 6 ? * SUN *)"
   schedule_expression_timezone = "Europe/Paris"
 
   target {

--- a/marketplace-demo/variables.tf
+++ b/marketplace-demo/variables.tf
@@ -1,0 +1,10 @@
+variable "image_tag" {
+  description = "Image tag for the container"
+  type        = string
+}
+
+variable "default_users" {
+  description = "Default users configuration"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION

Adds a new Marketplace Demo service that’s meant to be ephemeral: no persistent storage and a weekly reset. This will replace the Private Demo deployment soon.

The key changes are:
- Storage is ephemeral: All data is lost in every deploy.
- We are forcing a deploy every Sunday at 06:00 CET
- It uses the latest stable Home Assistant docker image on each deploy.
- Demo users are created based on DEFAULT_USERS env variable.
- It also injects a default dashboard with some version reference for debugging purposes.

Why

This is for marketplace app validation: a temporary demo environment where we don’t need to maintain state, and it’s helpful to regularly start fresh.