### PR TITLE
Hosted Home Assistant Sandbox for User Interviews

### DIFF
--- a/product-demo/efs.tf
+++ b/product-demo/efs.tf
@@ -1,6 +1,6 @@
 
 resource "aws_efs_file_system" "efs" {
-  creation_token = "efs"
+  creation_token = "product-demo-efs-${terraform.workspace}-eu-central-1"
 
   tags = {
     Name = "ProductDemo"

--- a/product-demo/efs.tf
+++ b/product-demo/efs.tf
@@ -9,7 +9,7 @@ resource "aws_efs_file_system" "efs" {
 
 
 resource "aws_security_group" "efs" {
-  vpc_id = data.tfe_outputs.infrastructure.values["eu-north-1"].network_id
+  vpc_id = data.tfe_outputs.infrastructure.values["eu-central-1"].network_id
 
   egress {
     from_port   = 0
@@ -28,7 +28,7 @@ resource "aws_security_group" "efs" {
 
 resource "aws_efs_mount_target" "mount" {
   for_each = toset(
-    nonsensitive(data.tfe_outputs.infrastructure.values["eu-north-1"].private_subnets),
+    nonsensitive(data.tfe_outputs.infrastructure.values["eu-central-1"].private_subnets),
   )
 
   file_system_id  = aws_efs_file_system.efs.id

--- a/product-demo/efs.tf
+++ b/product-demo/efs.tf
@@ -1,0 +1,38 @@
+
+resource "aws_efs_file_system" "efs" {
+  creation_token = "efs"
+
+  tags = {
+    Name = "ProductDemo"
+  }
+}
+
+
+resource "aws_security_group" "efs" {
+  vpc_id = data.tfe_outputs.infrastructure.values["eu-north-1"].network_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_efs_mount_target" "mount" {
+  for_each = toset(
+    nonsensitive(data.tfe_outputs.infrastructure.values["eu-north-1"].private_subnets),
+  )
+
+  file_system_id  = aws_efs_file_system.efs.id
+  subnet_id       = each.value
+  security_groups = [aws_security_group.efs.id]
+
+}

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -27,6 +27,7 @@ provider "aws" {
 
   default_tags {
     tags = {
+      department = "product"
       application = "product-demo"
     }
   }

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -27,7 +27,7 @@ provider "aws" {
 
   default_tags {
     tags = {
-      department = "product"
+      department  = "product"
       application = "product-demo"
     }
   }

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -47,7 +47,23 @@ module "webservice_product_demo" {
   cloudflare_proxy  = false
   ecs_memory        = 2048
 
+  container_volumes = [
+    { name : "product_demo_config",
+      efs_volume_configuration : [
+        {
+          file_system_id : aws_efs_file_system.efs.id,
+        }
+      ],
+    }
+  ]
+
   container_definitions = {
+    mountPoints : [
+      {
+        sourceVolume : "product_demo_config",
+        containerPath : "/config"
+      }
+    ],
     environment = [
       {
         name  = "DEFAULT_USERS"

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -3,7 +3,7 @@ terraform {
     organization = "home_assistant"
 
     workspaces {
-      name = "product_demo"
+      name = "product-demo"
     }
   }
 

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -46,6 +46,7 @@ module "webservice_product_demo" {
   port              = 8123
   cloudflare_proxy  = false
   ecs_memory        = 2048
+  region            = "eu-central-1"
 
   container_volumes = [
     { name : "product_demo_config",

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -23,7 +23,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-north-1"
+  region = "eu-central-1"
 
   default_tags {
     tags = {

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -41,7 +41,7 @@ module "webservice_product_demo" {
   source = "../.modules/webservice"
 
   service_name      = "Product-Demo"
-  container_image   = "ghcr.io/home-assistant/marketplace-demo"
+  container_image   = "ghcr.io/home-assistant/home-assistant"
   container_version = var.image_tag
   port              = 8123
   cloudflare_proxy  = false
@@ -58,16 +58,14 @@ module "webservice_product_demo" {
   ]
 
   container_definitions = {
+    entryPoint : [
+      "/bin/bash", "-c",
+      "echo '${base64encode(var.configuration_yaml)}' | base64 -d > /config/configuration.yaml && exec /init"
+    ],
     mountPoints : [
       {
         sourceVolume : "product_demo_config",
         containerPath : "/config"
-      }
-    ],
-    environment = [
-      {
-        name  = "DEFAULT_USERS"
-        value = var.default_users
       }
     ]
   }

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -1,0 +1,58 @@
+terraform {
+  cloud {
+    organization = "home_assistant"
+
+    workspaces {
+      name = "product_demo"
+    }
+  }
+
+  required_version = "~> 1.14.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-north-1"
+
+  default_tags {
+    tags = {
+      application = "product-demo"
+    }
+  }
+}
+
+data "tfe_outputs" "infrastructure" {
+  organization = "home_assistant"
+  workspace    = "infrastructure"
+}
+
+module "webservice_product_demo" {
+  source = "../.modules/webservice"
+
+  service_name      = "Product-Demo"
+  container_image   = "ghcr.io/home-assistant/marketplace-demo"
+  container_version = var.image_tag
+  port              = 8123
+  cloudflare_proxy  = false
+  ecs_memory        = 2048
+
+  container_definitions = {
+    environment = [
+      {
+        name  = "DEFAULT_USERS"
+        value = var.default_users
+      }
+    ]
+  }
+}

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -46,7 +46,7 @@ module "webservice_product_demo" {
   container_version = var.image_tag
   port              = 8123
   cloudflare_proxy  = false
-  ecs_memory        = 2048
+  ecs_memory        = 1024
   region            = "eu-central-1"
 
   container_volumes = [

--- a/product-demo/outputs.tf
+++ b/product-demo/outputs.tf
@@ -1,0 +1,9 @@
+output "image_tag" {
+  description = "The image tag in use by the deployment"
+  value       = var.image_tag
+}
+
+output "fqdn" {
+  description = "FQDN of the service"
+  value       = module.webservice_product_demo.fqdn
+}

--- a/product-demo/outputs.tf
+++ b/product-demo/outputs.tf
@@ -7,3 +7,8 @@ output "fqdn" {
   description = "FQDN of the service"
   value       = module.webservice_product_demo.fqdn
 }
+
+output "configuration_yaml" {
+  description = "Content of configuration.yaml in use by the deployment"
+  value       = var.configuration_yaml
+}

--- a/product-demo/variables.tf
+++ b/product-demo/variables.tf
@@ -1,0 +1,10 @@
+variable "image_tag" {
+  description = "Image tag for the container"
+  type        = string
+}
+
+variable "default_users" {
+  description = "Default users configuration"
+  type        = string
+  sensitive   = true
+}

--- a/product-demo/variables.tf
+++ b/product-demo/variables.tf
@@ -8,4 +8,9 @@ variable "configuration_yaml" {
   description = "Content of configuration.yaml - written on every deploy"
   type        = string
   default     = "default_config:"
+
+  validation {
+    condition     = can(yamldecode(var.configuration_yaml))
+    error_message = "configuration_yaml must be valid YAML syntax"
+  }
 }

--- a/product-demo/variables.tf
+++ b/product-demo/variables.tf
@@ -1,10 +1,11 @@
 variable "image_tag" {
   description = "Image tag for the container"
   type        = string
+  default     = "stable"
 }
 
-variable "default_users" {
-  description = "Default users configuration"
+variable "configuration_yaml" {
+  description = "Content of configuration.yaml - written on every deploy"
   type        = string
-  sensitive   = true
+  default     = "default_config:"
 }


### PR DESCRIPTION
This PR adds a remotely accessible **sandbox Home Assistant instance** to support upcoming **Product/Research user interviews**, allowing participants to explore a "dummy" environment even if they don't have Home Assistant installed.

### Why

- The Demo frontend experience is close to ideal, but interviews require the ability to **save changes, navigate across sessions, and explore freely**.
- We need a simple hosted environment with a stable link.

### What's included

- Deployment of the **stock Home Assistant image** (`ghcr.io/home-assistant/home-assistant`) on ECS in `eu-central-1` with 2GB RAM.
- **EFS-backed persistent storage** at `/config` — data survives container restarts and redeployments.
- **Terraform-managed `configuration.yaml`** — written on every deploy via a base64-encoded entrypoint override, so the instance config is always the source of truth from Terraform. No one can permanently modify the HA config from the UI.
- **Configurable version** — `image_tag` defaults to `stable` but can be pinned to a specific release (e.g. `2026.2.0`).
- **Configurable config** — `configuration_yaml` variable controls what gets written to `configuration.yaml` on each deploy.

### How resets work

- Redeploying overwrites `configuration.yaml` but preserves the rest of `/config` (database, users, etc.) on EFS.
- To fully reset, the EFS contents need to be wiped manually.
- On redeploy, the instance picks up whatever `image_tag` is set (latest stable by default).

### Ownership / Responsibilities

- **Product team owns and maintains the content** inside the instance (dashboards, automations, users).
- **Infra supports deployment + performs resets** upon request.