### PR TITLE
Temporarily move product-demo to us-east-1 to use existing ACM certificate

### DIFF
--- a/product-demo/efs.tf
+++ b/product-demo/efs.tf
@@ -1,6 +1,6 @@
 
 resource "aws_efs_file_system" "efs" {
-  creation_token = "product-demo-efs-${terraform.workspace}-eu-central-1"
+  creation_token = "product-demo-efs-${terraform.workspace}-us-east-1"
 
   tags = {
     Name = "ProductDemo"
@@ -9,7 +9,7 @@ resource "aws_efs_file_system" "efs" {
 
 
 resource "aws_security_group" "efs" {
-  vpc_id = data.tfe_outputs.infrastructure.values["eu-central-1"].network_id
+  vpc_id = data.tfe_outputs.infrastructure.values["us-east-1"].network_id
 
   egress {
     from_port   = 0
@@ -28,7 +28,7 @@ resource "aws_security_group" "efs" {
 
 resource "aws_efs_mount_target" "mount" {
   for_each = toset(
-    nonsensitive(data.tfe_outputs.infrastructure.values["eu-central-1"].private_subnets),
+    nonsensitive(data.tfe_outputs.infrastructure.values["us-east-1"].private_subnets),
   )
 
   file_system_id  = aws_efs_file_system.efs.id

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -23,7 +23,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-central-1"
+  region = "us-east-1"
 
   default_tags {
     tags = {
@@ -47,7 +47,7 @@ module "webservice_product_demo" {
   port              = 8123
   cloudflare_proxy  = false
   ecs_memory        = 1024
-  region            = "eu-central-1"
+  region            = "us-east-1"
 
   container_volumes = [
     { name : "product_demo_config",


### PR DESCRIPTION
### Context
Our wildcard ACM certificate is provisioned only in us-east-1 (certificate.tf). ACM certificates are regional AWS resources and cannot be used by services running in other regions.

### Temporary fix
Rather than refactoring the infrastructure workspace to provision per-region certificates — which requires careful planning around Terraform state and downstream consumers — we are temporarily relocating this service to us-east-1 where the existing certificate is available.

### Follow-up
This will be reverted once the infrastructure workspace is properly refactored to support regional ACM certificates. That work involves:

* Moving certificate resources into the region module
* Updating outputs and all downstream workspaces that consume certificate ARNs