### PR TITLE
fix(product-demo): prevent error "Instance already running" in product-demo

### DIFF
--- a/.modules/service/ecs.tf
+++ b/.modules/service/ecs.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_service" "service" {
   task_definition                    = aws_ecs_task_definition.task.arn
   desired_count                      = 1
   deployment_minimum_healthy_percent = var.rolling_updates ? 100 : 0
-  deployment_maximum_percent         = 200
+  deployment_maximum_percent         = var.deployment_maximum_percent
   launch_type                        = var.launch_type
 
 }

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -65,3 +65,9 @@ variable "rolling_updates" {
   default     = false
   type        = bool
 }
+
+variable "deployment_maximum_percent" {
+  description = "Upper limit on the number of tasks that can run during a deployment"
+  default     = 200
+  type        = number
+}

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -70,4 +70,9 @@ variable "deployment_maximum_percent" {
   description = "Upper limit on the number of tasks that can run during a deployment"
   default     = 200
   type        = number
+
+  validation {
+    condition = !var.rolling_updates || var.deployment_maximum_percent >= 200
+    error_message = "deployment_maximum_percent must be at least 200 when rolling_updates is true, so ECS can start a replacement task for a service with desired_count = 1 and deployment_minimum_healthy_percent = 100."
+  }
 }

--- a/.modules/service/variables.tf
+++ b/.modules/service/variables.tf
@@ -72,7 +72,7 @@ variable "deployment_maximum_percent" {
   type        = number
 
   validation {
-    condition = !var.rolling_updates || var.deployment_maximum_percent >= 200
+    condition     = !var.rolling_updates || var.deployment_maximum_percent >= 200
     error_message = "deployment_maximum_percent must be at least 200 when rolling_updates is true, so ECS can start a replacement task for a service with desired_count = 1 and deployment_minimum_healthy_percent = 100."
   }
 }

--- a/.modules/webservice/ecs.tf
+++ b/.modules/webservice/ecs.tf
@@ -4,7 +4,7 @@ resource "aws_ecs_service" "webservice" {
   task_definition                    = module.webservice.task_definition
   desired_count                      = 1
   deployment_minimum_healthy_percent = var.rolling_updates ? 100 : 0
-  deployment_maximum_percent         = 200
+  deployment_maximum_percent         = var.deployment_maximum_percent
   health_check_grace_period_seconds  = 90
   launch_type                        = var.launch_type
 

--- a/.modules/webservice/variables.tf
+++ b/.modules/webservice/variables.tf
@@ -84,9 +84,14 @@ variable "rolling_updates" {
 }
 
 variable "deployment_maximum_percent" {
-  description = "Upper limit on the number of tasks that can run during a deployment"
+  description = "Upper limit on the number of tasks that can run during a deployment. Must be within ECS' allowed range of 100-200. When rolling_updates is true, use a value greater than 100 (typically 200) to avoid stalled deployments."
   default     = 200
   type        = number
+
+  validation {
+    condition     = var.deployment_maximum_percent >= 100 && var.deployment_maximum_percent <= 200
+    error_message = "deployment_maximum_percent must be between 100 and 200. When rolling_updates is true, set deployment_maximum_percent to a value greater than 100 (typically 200) to avoid stalled ECS deployments."
+  }
 }
 
 variable "cloudflare_proxy" {

--- a/.modules/webservice/variables.tf
+++ b/.modules/webservice/variables.tf
@@ -83,6 +83,12 @@ variable "rolling_updates" {
   type        = bool
 }
 
+variable "deployment_maximum_percent" {
+  description = "Upper limit on the number of tasks that can run during a deployment"
+  default     = 200
+  type        = number
+}
+
 variable "cloudflare_proxy" {
   description = "Boolean to set if CloudFlare proxy should be active"
   default     = true

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -41,13 +41,13 @@ data "tfe_outputs" "infrastructure" {
 module "webservice_product_demo" {
   source = "../.modules/webservice"
 
-  service_name      = "Product-Demo"
-  container_image   = "ghcr.io/home-assistant/home-assistant"
-  container_version = var.image_tag
-  port              = 8123
-  cloudflare_proxy  = false
-  ecs_memory        = 1024
-  region                    = "eu-central-1"
+  service_name               = "Product-Demo"
+  container_image            = "ghcr.io/home-assistant/home-assistant"
+  container_version          = var.image_tag
+  port                       = 8123
+  cloudflare_proxy           = false
+  ecs_memory                 = 1024
+  region                     = "eu-central-1"
   deployment_maximum_percent = 100
 
   container_volumes = [

--- a/product-demo/main.tf
+++ b/product-demo/main.tf
@@ -47,7 +47,8 @@ module "webservice_product_demo" {
   port              = 8123
   cloudflare_proxy  = false
   ecs_memory        = 1024
-  region            = "eu-central-1"
+  region                    = "eu-central-1"
+  deployment_maximum_percent = 100
 
   container_volumes = [
     { name : "product_demo_config",

--- a/product-demo/variables.tf
+++ b/product-demo/variables.tf
@@ -8,9 +8,4 @@ variable "configuration_yaml" {
   description = "Content of configuration.yaml - written on every deploy"
   type        = string
   default     = "default_config:"
-
-  validation {
-    condition     = can(yamldecode(var.configuration_yaml))
-    error_message = "configuration_yaml must be valid YAML syntax"
-  }
 }


### PR DESCRIPTION
## Summary
- Add `deployment_maximum_percent` variable to service/webservice modules (default 200, preserving existing behavior)
- Set `deployment_maximum_percent = 100` for product-demo to prevent duplicate ECS tasks conflicting on the shared EFS mount (Instace already running error)
- Remove `yamldecode` validation on `configuration_yaml` since Home Assistant uses `!include` directives which are not standard YAML

## Test plan
- [ ] Verify `terraform plan` shows no unexpected changes for existing workspaces (default 200 unchanged)
- [ ] Verify product-demo deploys without duplicate instance errors
- [ ] Verify Home Assistant can save automations via the UI